### PR TITLE
runtime/mount: add "destination" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,8 @@ serde-value = "^0.1.0"
 semver = "^0.2.1"
 
 [build-dependencies]
-serde_codegen = { version = "^0.7.0", optional = true }
-syntex = { version = "^0.29.0", optional = true }
+serde_codegen = { version = "^0.7.9", optional = true }
 
 [features]
-stable = ["serde_codegen", "syntex"]
+stable = ["serde_codegen"]
 unstable = ["serde_macros"]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
-#[cfg(feature = "syntex")]
+#[cfg(feature = "serde_codegen")]
 fn main() {
-    extern crate syntex;
     extern crate serde_codegen;
 
     use std::env;
@@ -14,11 +13,8 @@ fn main() {
         let src = Path::new(src);
         let dst = Path::new(&out_dir).join(dst);
 
-        let mut registry = syntex::Registry::new();
-
-        serde_codegen::register(&mut registry);
-        registry.expand("ocf", &src, &dst).unwrap();
+        serde_codegen::expand(&src, &dst).unwrap();
     }
 }
-#[cfg(not(feature = "syntex"))]
+#[cfg(not(feature = "serde_codegen"))]
 fn main() { }

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -5,8 +5,8 @@
 #[cfg(feature = "unstable")]
 include!("lib.rs");
 
-#[cfg(feature = "syntex")]
+#[cfg(feature = "serde_codegen")]
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));
 
-#[cfg(not(any(feature = "unstable", feature = "syntex")))]
+#[cfg(not(any(feature = "unstable", feature = "serde_codegen")))]
 error_expected_unstable_or_stable_feature!();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -24,6 +24,7 @@ pub struct Mount {
     #[serde(rename = "type")]
     pub kind: String,
     pub source: String,
+    pub destination: String,
     #[serde(default, skip_serializing_if="Vec::is_empty")]
     pub options: Vec<String>,
 }

--- a/tests/runtime.json
+++ b/tests/runtime.json
@@ -3,6 +3,7 @@
 		"cgroup": {
 			"type": "cgroup",
 			"source": "cgroup",
+			"destination": "/sys/fs/cgroup",
 			"options": [
 				"nosuid",
 				"noexec",
@@ -14,6 +15,7 @@
 		"dev": {
 			"type": "tmpfs",
 			"source": "tmpfs",
+			"destination": "/tmp",
 			"options": [
 				"nosuid",
 				"strictatime",
@@ -24,6 +26,7 @@
 		"devpts": {
 			"type": "devpts",
 			"source": "devpts",
+			"destination": "/dev/pts",
 			"options": [
 				"nosuid",
 				"noexec",
@@ -36,6 +39,7 @@
 		"mqueue": {
 			"type": "mqueue",
 			"source": "mqueue",
+			"destination": "/var/mqueue",
 			"options": [
 				"nosuid",
 				"noexec",
@@ -45,11 +49,13 @@
 		"proc": {
 			"type": "proc",
 			"source": "proc",
+			"destination": "/proc",
 			"options": null
 		},
 		"shm": {
 			"type": "tmpfs",
 			"source": "shm",
+			"destination": "/dev/shm",
 			"options": [
 				"nosuid",
 				"noexec",
@@ -61,6 +67,7 @@
 		"sysfs": {
 			"type": "sysfs",
 			"source": "sysfs",
+			"destination": "/sys",
 			"options": [
 				"nosuid",
 				"noexec",


### PR DESCRIPTION
This PR adds a mandatory "destination" field to `Mount`, as per latest [runtime-spec](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc3/config.md#mounts).

This also updates the codegen logic for stable toolchain, as [currently reccomended](https://users.rust-lang.org/t/here-is-how-to-avoid-being-broken-by-syntex-updates/6189?u=dtolnay).