### PR TITLE
cargo: update to serde 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ license = "MIT"
 path = "src/mod.rs"
 
 [dependencies]
-serde = "^0.7.0"
-serde_macros = { version = "^0.7.0", optional = true }
-serde_json = "^0.7.0"
-serde-value = "^0.1.0"
-semver = "^0.2.1"
+serde = "0.9"
+serde_derive = { version = "0.9", optional = true }
+serde_json = "0.9"
+serde-value = "0.4"
+semver = "0.6"
 
 [build-dependencies]
-serde_codegen = { version = "^0.7.9", optional = true }
+serde_codegen = { version = "0.9", optional = true }
 
 [features]
 stable = ["serde_codegen"]
-unstable = ["serde_macros"]
+unstable = ["serde_derive"]

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,16 +7,11 @@ use runtime::RuntimeSpec;
 
 pub fn load<P: AsRef<Path>>(p: P) -> io::Result<(Spec, RuntimeSpec)> {
     fn err(e: serde_json::Error) -> io::Error {
-        match e {
-            serde_json::Error::Io(e) => e,
-            e => io::Error::new(io::ErrorKind::InvalidData, e),
-        }
+        io::Error::new(io::ErrorKind::InvalidData, e)
     }
     let p = p.as_ref();
     let config = try!(File::open(p.join("config.json")));
     let runtime = try!(File::open(p.join("runtime.json")));
-    Ok((
-        try!(Spec::from_read(config).map_err(err)),
-        try!(RuntimeSpec::from_read(runtime).map_err(err)),
-    ))
+    Ok((try!(Spec::from_read(config).map_err(err)),
+        try!(RuntimeSpec::from_read(runtime).map_err(err))))
 }

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -1,6 +1,9 @@
-#![cfg_attr(feature = "unstable", plugin(serde_macros))]
 #![cfg_attr(feature = "unstable", feature(plugin, custom_derive, custom_attribute))]
 #![doc(html_root_url="https://arcnmx.github.io/ocf-rs")]
+
+#[cfg(feature = "unstable")]
+#[macro_use]
+extern crate serde_derive;
 
 #[cfg(feature = "unstable")]
 include!("lib.rs");


### PR DESCRIPTION
This PR updates to latest serde version (0.9). This retains
compatibility with older rustc (<1.15) via codegen, but it can be
dropped at a later time.